### PR TITLE
Implement -add to enable creation of new Credentials entites on GCD

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/m-lab/go/flagx"
@@ -21,6 +23,15 @@ const (
 var (
 	node      = flag.String("node", "", "The node's name.")
 	projectID = flag.String("project", defaultProjectID, "Project ID to use.")
+	bmcUser   = flag.String("bmcuser", "",
+		"BMC username (for adding or updating a BMC.)")
+	bmcPass = flag.String("bmcpassword", "",
+		"BMC password (for adding or updating a BMC.)")
+	bmcAddr = flag.String("addr", "",
+		"BMC IP address (for adding or updating a BMC.)")
+
+	// Actions
+	addAction = flag.Bool("add", false, "Add a new node to GCS.")
 
 	// These allow for testing.
 	// TODO: remove this once https://github.com/m-lab/reboot-service/issues/12
@@ -37,6 +48,59 @@ func usage() {
 	osExit(1)
 }
 
+func add() error {
+	// Add a new BMC to Google Cloud Datastore
+	var err error
+	if *bmcUser == "" || *bmcPass == "" || *bmcAddr == "" {
+		return errors.New("bmcuser, bmcpass and bmcaddr are required")
+	}
+
+	creds := &creds.Credentials{
+		Address:  *bmcAddr,
+		Hostname: *node,
+		Model:    "DRAC",
+		Username: *bmcUser,
+		Password: *bmcPass,
+	}
+
+	log.Printf("Adding credentials for host %v\n", *node)
+	provider := credsNewProvider(*projectID, namespace)
+
+	// Provider.AddCredentials will create the entity regardless of whether it
+	// exists already or not, so we need to explicitly check to prevent
+	// overriding the existing entity by mistake.
+	_, err = provider.FindCredentials(context.Background(), *node)
+	if err == nil {
+		return fmt.Errorf("Credentials for hostname %v already exist "+
+			"- did you mean -update?", *node)
+	}
+
+	err = provider.AddCredentials(context.Background(), *node, creds)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func fetch() error {
+	// Default behavior (if no other actions have been specified) is to fetch
+	// credentials for the selected node.
+	provider := credsNewProvider(*projectID, namespace)
+	creds, err := provider.FindCredentials(context.Background(), *node)
+	if err != nil {
+		return err
+	}
+
+	jsonOutput, err := json.MarshalIndent(creds, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(jsonOutput))
+	return nil
+}
+
 func main() {
 	flag.Usage = usage
 	flag.Parse()
@@ -48,12 +112,14 @@ func main() {
 		flag.Usage()
 	}
 
-	provider := credsNewProvider(*projectID, namespace)
-	creds, err := provider.FindCredentials(context.Background(), *node)
-	rtx.Must(err, "Error while fetching credentials")
-
-	jsonOutput, err := json.MarshalIndent(creds, "", "  ")
-	rtx.Must(err, "Cannot marshal JSON")
-
-	fmt.Println(string(jsonOutput))
+	// Handle action flags
+	//
+	// -add: create a new entity
+	// -update: updates an existing entity (TODO)
+	// no flags: fetch credentials
+	if *addAction {
+		rtx.Must(add(), "Error while adding node")
+	} else {
+		rtx.Must(fetch(), "Error while fetching credentials")
+	}
 }

--- a/main.go
+++ b/main.go
@@ -75,7 +75,10 @@ func addCredentials() error {
 	rtx.Must(provider.AddCredentials(context.Background(), *node, creds),
 		"Error while adding Credentials")
 
-	log.Infof("Added %v\nUsername: %s\nPassword: %s", *node, *bmcUser, *bmcPass)
+	jsonOutput, err := json.MarshalIndent(creds, "", "  ")
+	rtx.Must(err, "Cannot marshal JSON output")
+
+	fmt.Println(string(jsonOutput))
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -103,6 +103,8 @@ func main() {
 	}
 
 	// Handle action flags
+	// TODO(roberto): use a module enabling subcommands (such as kingpin)
+	// instead of "flag".
 	//
 	// -add: create a new entity
 	// -update: updates an existing entity (TODO)

--- a/main.go
+++ b/main.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"log"
 	"os"
 
+	"github.com/apex/log"
 	"github.com/m-lab/go/flagx"
 	"github.com/m-lab/go/rtx"
 
@@ -48,7 +48,7 @@ func usage() {
 // addCredentials adds a new BMC to Google Cloud Datastore.
 func addCredentials() error {
 	if *bmcUser == "" || *bmcPass == "" || *bmcAddr == "" {
-		log.Println("bmcuser, bmcpassword and addr are required")
+		log.Error("bmcuser, bmcpassword and addr are required")
 		osExit(1)
 	}
 
@@ -60,7 +60,7 @@ func addCredentials() error {
 		Password: *bmcPass,
 	}
 
-	log.Printf("Adding credentials for host %v\n", *node)
+	log.Infof("Adding credentials for host %v\n", *node)
 	provider := credsNewProvider(*projectID, namespace)
 
 	// Provider.AddCredentials will create the entity regardless of whether it
@@ -68,13 +68,14 @@ func addCredentials() error {
 	// overriding the existing entity by mistake.
 	_, err := provider.FindCredentials(context.Background(), *node)
 	if err == nil {
-		log.Printf("Credentials for hostname %v already exist\n", *node)
+		log.Errorf("Credentials for hostname %v already exist\n", *node)
 		osExit(1)
 	}
 
 	rtx.Must(provider.AddCredentials(context.Background(), *node, creds),
 		"Error while adding Credentials")
 
+	log.Infof("Added %v\nUsername: %s\nPassword: %s", *node, *bmcUser, *bmcPass)
 	return nil
 }
 
@@ -103,7 +104,7 @@ func main() {
 	}
 
 	// Handle action flags
-	// TODO(roberto): use a module enabling subcommands (such as kingpin)
+	// TODO(roberto): use a package that handles subcommands (such as kingpin)
 	// instead of "flag".
 	//
 	// -add: create a new entity

--- a/main_test.go
+++ b/main_test.go
@@ -2,26 +2,14 @@ package main
 
 import (
 	"context"
-	"errors"
 	"testing"
+
+	"github.com/m-lab/reboot-service/creds/credstest"
 
 	"github.com/m-lab/go/osx"
 	"github.com/m-lab/reboot-service/creds"
 	"github.com/stretchr/testify/assert"
 )
-
-type providerMock struct {
-	returnValue *creds.Credentials
-	returnErr   bool
-}
-
-func (p *providerMock) FindCredentials(ctx context.Context, node string) (*creds.Credentials, error) {
-	if p.returnErr {
-		return nil, errors.New("error while fetching credentials")
-	}
-
-	return p.returnValue, nil
-}
 
 func Test_main(t *testing.T) {
 	// Create fake Credentials.
@@ -33,7 +21,7 @@ func Test_main(t *testing.T) {
 		Model:    "drac",
 	}
 
-	// Replace osExit and logFatalf so that tests don't stop running.
+	// Replace osExit so that tests don't stop running.
 	osExit = func(code int) {
 		if code != 1 {
 			t.Fatalf("Expected a 1 exit code, got %d.", code)
@@ -44,23 +32,51 @@ func Test_main(t *testing.T) {
 
 	oldCredsNewProvider := credsNewProvider
 
+	// No node specified, just print usage and return.
 	t.Run("failure-no-node-provided", func(t *testing.T) {
-		// No node specified, just print usage and return.
 		assert.PanicsWithValue(t, "os.Exit called", main, "os.Exit was not called")
 	})
 
-	// Set up env variables to simulate flags.
-	restoreNode := osx.MustSetenv("NODE", "mlab4.lga0t.measurement-lab.org")
-	defer restoreNode()
-
-	credsNewProvider = func(projectID string, namespace string) creds.Provider {
-		return &providerMock{
-			returnValue: fakeCreds,
-		}
+	// Set up a FakeProvider with fake credentials.
+	credsNewProvider = func(string, string) creds.Provider {
+		prov := credstest.NewProvider()
+		prov.AddCredentials(context.Background(), "mlab4d.lga0t.measurement-lab.org", fakeCreds)
+		return prov
 	}
+	// Set up env variables to simulate flags.
+	restoreNode := osx.MustSetenv("NODE", "mlab4d.lga0t.measurement-lab.org")
+	defer restoreNode()
 	t.Run("success", func(t *testing.T) {
 		main()
 	})
 
+	// main() should successfully add a new node.
+	osx.MustSetenv("NODE", "mlab1d.lga0t.measurement-lab.org")
+	restoreAdd := osx.MustSetenv("ADD", "1")
+	restoreUser := osx.MustSetenv("BMCUSER", "username")
+	restorePass := osx.MustSetenv("BMCPASSWORD", "password")
+	restoreAddr := osx.MustSetenv("ADDR", "127.0.0.1")
+	defer restoreAdd()
+	defer restoreUser()
+	defer restorePass()
+	defer restoreAddr()
+	t.Run("success-node-added", func(t *testing.T) {
+		main()
+	})
+
+	// main() should exit if the node already exists.
+	osx.MustSetenv("NODE", "mlab4d.lga0t.measurement-lab.org")
+	t.Run("failure-add-node-already-exists", func(t *testing.T) {
+		assert.PanicsWithValue(t, "os.Exit called", main,
+			"os.Exit was not called")
+	})
+
+	osx.MustSetenv("BMCUSER", "")
+	// main() should fail when trying to -add without specifying the required
+	// arguments (username, password and address).
+	t.Run("failure-add-missing-args", func(t *testing.T) {
+		assert.PanicsWithValue(t, "os.Exit called", main,
+			"os.Exit was not called")
+	})
 	credsNewProvider = oldCredsNewProvider
 }


### PR DESCRIPTION
This PR implements the `-add` flag, to create new Credentials on GCD. 

Closes https://github.com/m-lab/ops-tracker/issues/669.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/bmctool/3)
<!-- Reviewable:end -->
