### PR TITLE
Silence flagx logs and default to mlab-oti

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	defaultProjectID = "mlab-sandbox"
+	defaultProjectID = "mlab-oti"
 	namespace        = "reboot-api"
 )
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"os"
+
+	stdlog "log"
 
 	"github.com/apex/log"
 	"github.com/m-lab/go/flagx"
@@ -91,7 +94,9 @@ func printCredentials(host string) {
 func main() {
 	flag.Usage = usage
 	flag.Parse()
+	stdlog.SetOutput(ioutil.Discard)
 	rtx.Must(flagx.ArgsFromEnv(flag.CommandLine), "Could not parse env vars")
+	stdlog.SetOutput(os.Stdout)
 
 	// No node specified, nothing to do.
 	if *node == "" {


### PR DESCRIPTION
This PR silences the flagx.ArgsFromEnv logs at startup and changes the default project to `mlab-oti`.

Example output:
```
$ ./bmctool -node mlab1d.lga0t.measurement-lab.org
{
  "hostname": "mlab1d.lga0t.measurement-lab.org",
  "username": "<redacted>",
  "password": "<redacted>",
  "model": "DRAC",
  "address": "4.14.159.68"
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/bmctool/7)
<!-- Reviewable:end -->
