### PR TITLE
Automatically infer GCP project to use from the node name

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -51,7 +51,12 @@ func addCredentials() {
 		log.Error("BMCUSER and BMCPASS must not be empty.")
 		osExit(1)
 	}
+
 	bmcHost = makeBMCHostname(bmcHost)
+	if projectID == "" {
+		projectID = getProjectID(bmcHost)
+	}
+
 	creds := &creds.Credentials{
 		Address:  bmcAddr,
 		Hostname: bmcHost,

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -15,7 +15,8 @@ var getCmd = &cobra.Command{
 	Long: `This command gets a Credentials entity for a given BMC from Google
 Cloud Datastore.
 
-The GCP project to use can be specified by providing the --project flag.`,
+The GCP project to use can be specified by providing the --project flag,
+otherwise it will be inferred by the node name.`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		host := args[0]
@@ -30,8 +31,13 @@ func init() {
 // printCredentials retrieves credentials for a given hostname and prints them
 // in JSON format.
 func printCredentials(host string) {
+	bmcHost := makeBMCHostname(host)
+	if projectID == "" {
+		projectID = getProjectID(bmcHost)
+	}
+
 	provider := credsNewProvider(projectID, namespace)
-	creds, err := provider.FindCredentials(context.Background(), makeBMCHostname(host))
+	creds, err := provider.FindCredentials(context.Background(), bmcHost)
 	rtx.Must(err, "Cannot fetch credentials")
 
 	fmt.Print(creds)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,8 +20,8 @@ const (
 var (
 	projectID string
 
-	sandboxRegex = regexp.MustCompile("^mlab[1-4]d?\\.[a-zA-Z]{3}[0-9]t.*")
-	stagingRegex = regexp.MustCompile("^mlab4d?\\.[a-zA-Z]{3}[0-9]{2}.*")
+	sandboxRegex = regexp.MustCompile("[a-zA-Z]{3}[0-9]t")
+	stagingRegex = regexp.MustCompile("^mlab4")
 
 	// These allow for testing.
 	credsNewProvider = creds.NewProvider

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"strings"
 
 	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/reboot-service/creds"
@@ -15,10 +14,14 @@ const (
 	namespace        = "reboot-api"
 	prodProjectID    = "mlab-oti"
 	stagingProjectID = "mlab-staging"
+	sandboxProjectID = "mlab-sandbox"
 )
 
 var (
 	projectID string
+
+	sandboxRegex = regexp.MustCompile("^mlab[1-4]d?\\.[a-zA-Z]{3}[0-9]t.*")
+	stagingRegex = regexp.MustCompile("^mlab4d?\\.[a-zA-Z]{3}[0-9]{2}.*")
 
 	// These allow for testing.
 	credsNewProvider = creds.NewProvider
@@ -79,11 +82,14 @@ func makeBMCHostname(name string) string {
 	return fmt.Sprintf("%s.%s.measurement-lab.org", node, site)
 }
 
-// getProjectID returns the staging GCP project if the hostname contains
-// "mlab4", or the production project otherwise.
+// getProjectID returns the correct GCP project to use based on the hostname.
 func getProjectID(host string) string {
-	if strings.Contains(host, "mlab4") {
+	if sandboxRegex.MatchString(host) {
+		return sandboxProjectID
+	}
+	if stagingRegex.MatchString(host) {
 		return stagingProjectID
 	}
+
 	return prodProjectID
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/reboot-service/creds"
@@ -12,7 +13,8 @@ import (
 
 const (
 	namespace        = "reboot-api"
-	defaultProjectID = "mlab-oti"
+	prodProjectID    = "mlab-oti"
+	stagingProjectID = "mlab-staging"
 )
 
 var (
@@ -43,7 +45,7 @@ func Execute() {
 func init() {
 	// The --project flag is used by several commands, thus it's defined
 	// as global ("Persistent") flag here.
-	rootCmd.PersistentFlags().StringVar(&projectID, "project", defaultProjectID,
+	rootCmd.PersistentFlags().StringVar(&projectID, "project", "",
 		"Project ID to use")
 }
 
@@ -75,4 +77,13 @@ func makeBMCHostname(name string) string {
 		node = node + "d"
 	}
 	return fmt.Sprintf("%s.%s.measurement-lab.org", node, site)
+}
+
+// getProjectID returns the staging GCP project if the hostname contains
+// "mlab4", or the production project otherwise.
+func getProjectID(host string) string {
+	if strings.Contains(host, "mlab4") {
+		return stagingProjectID
+	}
+	return prodProjectID
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -55,6 +55,11 @@ func Test_getProjectID(t *testing.T) {
 			host: "mlab4.abc01.measurement-lab.org",
 			want: "mlab-staging",
 		},
+		{
+			name: "sandbox-node",
+			host: "mlab4.abc0t.measurement-lab.org",
+			want: "mlab-sandbox",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,6 +1,8 @@
 package cmd
 
-import "testing"
+import (
+	"testing"
+)
 
 func Test_makeBMCHostname(t *testing.T) {
 	tests := []struct {
@@ -32,6 +34,32 @@ func Test_makeBMCHostname(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := makeBMCHostname(tt.name); got != tt.want {
 				t.Errorf("makeBMCHostname() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getProjectID(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{
+			name: "prod-node",
+			host: "mlab1.abc01.measurement-lab.org",
+			want: "mlab-oti",
+		},
+		{
+			name: "staging-node",
+			host: "mlab4.abc01.measurement-lab.org",
+			want: "mlab-staging",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getProjectID(tt.host); got != tt.want {
+				t.Errorf("getProjectID() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
This PR makes `bmctool` select the production or staging GCP project to use according to the node name. The `--project` flag is still available to override it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/bmctool/22)
<!-- Reviewable:end -->
