### PR TITLE
Add subcommand "bmctool set" to update existing entities

### DIFF
--- a/cmd/set.go
+++ b/cmd/set.go
@@ -15,8 +15,9 @@ var (
 	setCmd = &cobra.Command{
 		Use:   "set <hostname>",
 		Short: "Updates the Credentials entity for the specified hostname",
-		Long:  `This command updates the Credentials entity on GCD.`,
-		Args:  cobra.MinimumNArgs(1),
+		Long: `This command updates the Credentials entity on GCD. If the flag
+corresponding to a field is not specified, that field will not be updated.`,
+		Args: cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			bmcHost = args[0]
 			setCredentials()

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/m-lab/go/rtx"
+	"github.com/spf13/viper"
+
+	"github.com/apex/log"
+	"github.com/spf13/cobra"
+)
+
+var (
+	setCmd = &cobra.Command{
+		Use:   "set <hostname>",
+		Short: "Updates the Credentials entity for the specified hostname",
+		Long:  `This command updates the Credentials entity on GCD.`,
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			bmcHost = args[0]
+			setCredentials()
+		},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(setCmd)
+
+	viper.AutomaticEnv()
+
+	setCmd.Flags().StringVar(&bmcUser, "user", viper.GetString("BMCUSER"),
+		"BMC username")
+	setCmd.Flags().StringVar(&bmcPass, "pass", viper.GetString("BMCPASS"),
+		"BMC password")
+	setCmd.Flags().StringVar(&bmcAddr, "addr", viper.GetString("BMCADDR"),
+		"BMC IPv4 address")
+}
+
+// setCredentials updates a Credentials entity on Google Cloud Datastore.
+func setCredentials() {
+	bmcHost = makeBMCHostname(bmcHost)
+	if projectID == "" {
+		projectID = getProjectID(bmcHost)
+	}
+
+	log.Infof("Updating credentials for host %v", bmcHost)
+	provider := credsNewProvider(projectID, namespace)
+
+	creds, err := provider.FindCredentials(context.Background(), bmcHost)
+	if err != nil {
+		log.Errorf("Error while retrieving credentials for %s: %v", bmcHost, err)
+		osExit(1)
+	}
+
+	// Update fields. When a new value is not specified, the corresponding
+	// field is left as is.
+	if bmcAddr != "" {
+		creds.Address = bmcAddr
+	}
+	if bmcUser != "" {
+		creds.Username = bmcUser
+	}
+	if bmcPass != "" {
+		creds.Password = bmcPass
+	}
+	rtx.Must(provider.AddCredentials(context.Background(), bmcHost, creds),
+		"Error while adding Credentials")
+	fmt.Print(creds)
+}

--- a/cmd/set_test.go
+++ b/cmd/set_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/m-lab/reboot-service/creds"
+	"github.com/m-lab/reboot-service/creds/credstest"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_setCredentials(t *testing.T) {
+	// Create fake Credentials.
+	fakeCreds := &creds.Credentials{
+		Address:  "127.0.0.1",
+		Hostname: "mlab4d.lga0t.measurement-lab.org",
+		Username: "username",
+		Password: "password",
+		Model:    "DRAC",
+	}
+
+	// Replace osExit so that tests don't stop running.
+	osExit = func(code int) {
+		if code != 1 {
+			t.Fatalf("Expected a 1 exit code, got %d.", code)
+		}
+
+		panic("os.Exit called")
+	}
+
+	oldCredsNewProvider := credsNewProvider
+	projectID = ""
+
+	// Set up a FakeProvider with fake credentials.
+	prov := credstest.NewProvider()
+	prov.AddCredentials(context.Background(), "mlab4d.lga0t.measurement-lab.org", fakeCreds)
+	credsNewProvider = func(string, string) creds.Provider {
+		return prov
+	}
+
+	// setCredentials should successfully change an existing entity
+	bmcHost = "mlab4d.lga0t"
+	bmcUser = "testuser"
+	bmcPass = "testpass"
+	bmcAddr = "127.0.0.2"
+	setCredentials()
+
+	// Check the node that's been just added.
+	c, err := prov.FindCredentials(context.Background(), "mlab4d.lga0t.measurement-lab.org")
+	if err != nil {
+		t.Errorf("FindCredentials() returned error: %v", err)
+	}
+	if c.Hostname != "mlab4d.lga0t.measurement-lab.org" ||
+		c.Username != "testuser" || c.Password != "testpass" ||
+		c.Address != "127.0.0.2" || c.Model != "DRAC" {
+		t.Errorf("setCredentials() didn't update the expected entity: %v", c)
+	}
+
+	// bmctool set should fail if called on a non-existing host.
+	bmcHost = "mlab4.abc01"
+	assert.PanicsWithValue(t, "os.Exit called", setCredentials,
+		"os.Exit was not called")
+
+	credsNewProvider = oldCredsNewProvider
+}


### PR DESCRIPTION
This PR adds a `bmctool set <hostname> --addr <ipv4 addr> --user <username> --pass <password>` subcommand.

None of the flags are mandatory. If they are not specified, that field will not be updated. They can also be passed via the `BMCUSER`, `BMCPASS` and `BMCADDR` environment variables.

The entity must exist already, so it does not replace `bmctool add`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/bmctool/23)
<!-- Reviewable:end -->
