### PR TITLE
Implement "bmctool delete <hostname>" subcommand

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -35,6 +35,10 @@ func deleteCredentials() {
 	provider := credsNewProvider(projectID, namespace)
 
 	err := provider.DeleteCredentials(context.Background(), bmcHost)
+	// Note: Deleting a key from Datastore does not return a NoSuchEntity error
+	// if the specified key does not exist, thus the error will be nil unless
+	// something else goes wrong during the deletion.
+	// See: https://github.com/googleapis/google-cloud-go/issues/501
 	if err != nil {
 		log.Errorf("Cannot delete credentials for %s: %v", bmcHost, err)
 		osExit(1)

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/apex/log"
+	"github.com/spf13/cobra"
+)
+
+var (
+	deleteCmd = &cobra.Command{
+		Use:   "delete <hostname>",
+		Short: "Deletes the Credentials entity for the specified hostname",
+		Long:  "This command deletes the Credentials entity on GCD.",
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			bmcHost = args[0]
+			deleteCredentials()
+		},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(deleteCmd)
+}
+
+// deleteCredentials updates a Credentials entity on Google Cloud Datastore.
+func deleteCredentials() {
+	bmcHost = makeBMCHostname(bmcHost)
+	if projectID == "" {
+		projectID = getProjectID(bmcHost)
+	}
+
+	log.Infof("Deleting credentials for host %v", bmcHost)
+	provider := credsNewProvider(projectID, namespace)
+
+	err := provider.DeleteCredentials(context.Background(), bmcHost)
+	if err != nil {
+		log.Errorf("Cannot delete credentials for %s: %v", bmcHost, err)
+		osExit(1)
+	}
+
+	log.Info("Credentials successfully deleted.")
+}

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/m-lab/reboot-service/creds"
+	"github.com/m-lab/reboot-service/creds/credstest"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_deleteCredentials(t *testing.T) {
+	// Create fake Credentials.
+	fakeCreds := &creds.Credentials{
+		Address:  "127.0.0.1",
+		Hostname: "mlab4d.lga0t.measurement-lab.org",
+		Username: "username",
+		Password: "password",
+		Model:    "DRAC",
+	}
+
+	// Replace osExit so that tests don't stop running.
+	osExit = func(code int) {
+		if code != 1 {
+			t.Fatalf("Expected a 1 exit code, got %d.", code)
+		}
+
+		panic("os.Exit called")
+	}
+
+	oldCredsNewProvider := credsNewProvider
+	projectID = ""
+
+	// Set up a FakeProvider with fake credentials.
+	prov := credstest.NewProvider()
+	prov.AddCredentials(context.Background(), "mlab4d.lga0t.measurement-lab.org", fakeCreds)
+	credsNewProvider = func(string, string) creds.Provider {
+		return prov
+	}
+
+	// deleteCredentials should successfully remove an existing entity.
+	bmcHost = "mlab4d.lga0t"
+	deleteCredentials()
+
+	_, err := prov.FindCredentials(context.Background(), "mlab4.lga0t")
+	if err == nil {
+		t.Errorf("deleteCredentials() did not delete Credentials.")
+	}
+
+	// deleteCredentials() should fail if provider.DeleteCredentials() fails.
+	// Since our FakeProvider fails if trying to delete a non-existing entity,
+	// calling deleteCredentials() again on the same key is enough to test it.
+	assert.PanicsWithValue(t, "os.Exit called", deleteCredentials,
+		"os.Exit was not called")
+
+	credsNewProvider = oldCredsNewProvider
+}


### PR DESCRIPTION
This PR implements the `bmctool delete <hostname>` subcommand.

Please note that it follows the same contract as Datastore's `Delete` operation, i.e. it guarantees that the entity does not exist anymore if no error is returned, but it does not complain if the entity didn't exist from the beginning.

However, as explained the comments, the FakeProvider used for testing **will** fail if asked to delete a non-existing entity. This simplifies testing.

I expect the build to fail due to test failures until https://github.com/m-lab/reboot-service/pull/25 is merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/bmctool/25)
<!-- Reviewable:end -->
