### PR TITLE
Update every usage of creds.NewProvider

### DIFF
--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -33,8 +33,8 @@ func Test_addCredentials(t *testing.T) {
 	// Set up a FakeProvider with fake credentials.
 	prov := credstest.NewProvider()
 	prov.AddCredentials(context.Background(), "mlab4d.lga0t.measurement-lab.org", fakeCreds)
-	credsNewProvider = func(string, string) creds.Provider {
-		return prov
+	credsNewProvider = func(creds.Connector, string, string) (creds.Provider, error) {
+		return prov, nil
 	}
 
 	// addCredentials should successfully add a new node.

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -3,6 +3,9 @@ package cmd
 import (
 	"context"
 
+	"github.com/m-lab/go/rtx"
+	"github.com/m-lab/reboot-service/creds"
+
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
 )
@@ -32,9 +35,11 @@ func deleteCredentials() {
 	}
 
 	log.Infof("Deleting credentials for host %v", bmcHost)
-	provider := credsNewProvider(projectID, namespace)
+	provider, err := credsNewProvider(&creds.DatastoreConnector{}, projectID, namespace)
+	rtx.Must(err, "Cannot connect to Datastore")
+	provider.Close()
 
-	err := provider.DeleteCredentials(context.Background(), bmcHost)
+	err = provider.DeleteCredentials(context.Background(), bmcHost)
 	// Note: Deleting a key from Datastore does not return a NoSuchEntity error
 	// if the specified key does not exist, thus the error will be nil unless
 	// something else goes wrong during the deletion.

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -34,8 +34,8 @@ func Test_deleteCredentials(t *testing.T) {
 	// Set up a FakeProvider with fake credentials.
 	prov := credstest.NewProvider()
 	prov.AddCredentials(context.Background(), "mlab4d.lga0t.measurement-lab.org", fakeCreds)
-	credsNewProvider = func(string, string) creds.Provider {
-		return prov
+	credsNewProvider = func(creds.Connector, string, string) (creds.Provider, error) {
+		return prov, nil
 	}
 
 	// deleteCredentials should successfully remove an existing entity.

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/m-lab/reboot-service/creds"
+
 	"github.com/m-lab/go/rtx"
 	"github.com/spf13/cobra"
 )
@@ -36,7 +38,10 @@ func printCredentials(host string) {
 		projectID = getProjectID(bmcHost)
 	}
 
-	provider := credsNewProvider(projectID, namespace)
+	provider, err := credsNewProvider(&creds.DatastoreConnector{}, projectID, namespace)
+	rtx.Must(err, "Cannot connect to Datastore")
+	defer provider.Close()
+
 	creds, err := provider.FindCredentials(context.Background(), bmcHost)
 	rtx.Must(err, "Cannot fetch credentials")
 

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -23,8 +23,8 @@ func Test_printCredentials(t *testing.T) {
 	// Set up a FakeProvider with fake credentials.
 	prov := credstest.NewProvider()
 	prov.AddCredentials(context.Background(), "mlab4d.lga0t.measurement-lab.org", fakeCreds)
-	credsNewProvider = func(string, string) creds.Provider {
-		return prov
+	credsNewProvider = func(creds.Connector, string, string) (creds.Provider, error) {
+		return prov, nil
 	}
 
 	// printCredentials is intentionally called with a short name here.

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/m-lab/reboot-service/creds"
+
 	"github.com/m-lab/go/rtx"
 	"github.com/spf13/viper"
 
@@ -46,7 +48,9 @@ func setCredentials() {
 	}
 
 	log.Infof("Updating credentials for host %v", bmcHost)
-	provider := credsNewProvider(projectID, namespace)
+	provider, err := credsNewProvider(&creds.DatastoreConnector{}, projectID, namespace)
+	rtx.Must(err, "Cannot connect to Datastore")
+	defer provider.Close()
 
 	creds, err := provider.FindCredentials(context.Background(), bmcHost)
 	if err != nil {

--- a/cmd/set_test.go
+++ b/cmd/set_test.go
@@ -34,8 +34,8 @@ func Test_setCredentials(t *testing.T) {
 	// Set up a FakeProvider with fake credentials.
 	prov := credstest.NewProvider()
 	prov.AddCredentials(context.Background(), "mlab4d.lga0t.measurement-lab.org", fakeCreds)
-	credsNewProvider = func(string, string) creds.Provider {
-		return prov
+	credsNewProvider = func(creds.Connector, string, string) (creds.Provider, error) {
+		return prov, nil
 	}
 
 	// setCredentials should successfully change an existing entity


### PR DESCRIPTION
This PR updates every usage of `creds.NewProvider` so that bmctool can be built again after changing that API. I expect the build to fail until https://github.com/m-lab/reboot-service/pull/28 is merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/bmctool/28)
<!-- Reviewable:end -->
