### PR TITLE
Add username to the SSH command when forwarding ports

### DIFF
--- a/cmd/forward.go
+++ b/cmd/forward.go
@@ -100,7 +100,7 @@ func forward(dstHost string) {
 		rtx.Must(err, "Cannot parse provided port")
 		portFwd = append(portFwd, p)
 	}
-	forwarder := newForwarder(tunnelHost, dstHost, portFwd)
+	forwarder := newForwarder(tunnelHost, sshUser, dstHost, portFwd)
 
 	ctx := context.Background()
 	rtx.Must(forwarder.Start(context.Background()), "Cannot start SSH tunnel")

--- a/cmd/forward_test.go
+++ b/cmd/forward_test.go
@@ -16,7 +16,7 @@ func (fm *forwarderMock) Start(context.Context) error {
 	return nil
 }
 
-func newForwarderMock(string, string, []forwarder.Port) forwarder.Forwarder {
+func newForwarderMock(string, string, string, []forwarder.Port) forwarder.Forwarder {
 	return &forwarderMock{}
 }
 
@@ -84,6 +84,8 @@ func Test_forward(t *testing.T) {
 
 	// bmctool forward should fail if the tunnel host or the SSH user aren't
 	// set.
+	sshUser = ""
+	tunnelHost = ""
 	assert.PanicsWithValue(t, "os.Exit called", func() { forward("mlab1.tst01") },
 		"os.Exit was not called")
 

--- a/cmd/keys_set.go
+++ b/cmd/keys_set.go
@@ -74,13 +74,17 @@ func setKey(host, idx, key string) {
 	}
 
 	if useTunnel {
+		if tunnelHost == "" || sshUser == "" {
+			log.Error("BMCTUNNELHOST and BMCTUNNELUSER must not be empty.")
+			osExit(1)
+		}
 		ports := []forwarder.Port{
 			{
 				Src: int(localPort),
 				Dst: int(bmcPort),
 			},
 		}
-		sshForwarder := forwarder.New(tunnelHost, bmcHost, ports)
+		sshForwarder := forwarder.New(tunnelHost, sshUser, bmcHost, ports)
 		sshForwarder.Start(context.Background())
 		connectionConfig.Hostname = "127.0.0.1"
 		connectionConfig.Port = 8060

--- a/forwarder/forwarder.go
+++ b/forwarder/forwarder.go
@@ -33,15 +33,19 @@ type sshForwarder struct {
 	// Tunnel host
 	tHost string
 
+	// Tunnel username
+	tUser string
+
 	// Destination host
 	dstHost string
 }
 
 // New returns an SSHForwarder with the provided tunnel host, destination host
 // and port mapping pairs.
-func New(tHost string, dstHost string, ports []Port) Forwarder {
+func New(tHost string, tUser string, dstHost string, ports []Port) Forwarder {
 	return &sshForwarder{
 		tHost:   tHost,
+		tUser:   tUser,
 		dstHost: dstHost,
 		ports:   ports,
 	}
@@ -58,7 +62,7 @@ func (f *sshForwarder) getPortParams() []string {
 func (f *sshForwarder) Start(ctx context.Context) error {
 	portParams := f.getPortParams()
 
-	args := []string{"-N", "-q", f.tHost}
+	args := []string{"-N", "-q", f.tUser + "@" + f.tHost}
 	args = append(args, portParams...)
 	log.Infof("Running %v", args)
 	cmd := exec.CommandContext(ctx, "ssh", args[1:]...)

--- a/forwarder/forwarder_test.go
+++ b/forwarder/forwarder_test.go
@@ -10,6 +10,7 @@ func Test_sshForwarder_getPortParams(t *testing.T) {
 		name    string
 		ports   []Port
 		tHost   string
+		tUser   string
 		dstHost string
 		want    []string
 	}{
@@ -26,6 +27,7 @@ func Test_sshForwarder_getPortParams(t *testing.T) {
 				},
 			},
 			tHost:   "tunnelhost",
+			tUser:   "user",
 			dstHost: "dsthost",
 			want: []string{
 				"-L4443:dsthost:443",
@@ -38,6 +40,7 @@ func Test_sshForwarder_getPortParams(t *testing.T) {
 			f := &sshForwarder{
 				ports:   tt.ports,
 				tHost:   tt.tHost,
+				tUser:   tt.tUser,
 				dstHost: tt.dstHost,
 			}
 			if got := f.getPortParams(); !reflect.DeepEqual(got, tt.want) {
@@ -48,7 +51,7 @@ func Test_sshForwarder_getPortParams(t *testing.T) {
 }
 
 func Test_New(t *testing.T) {
-	f := New("tunnelhost", "dsthost", []Port{})
+	f := New("tunnelhost", "user", "dsthost", []Port{})
 	if f == nil {
 		t.Errorf("New() returned nil.")
 	}


### PR DESCRIPTION
This previously worked only because our local username was the same as our username on the tunnel host (EB).

Also, fix a bug in `forward_test.go` where the test could get stuck if environment variables were already set to non-empty values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/bmctool/30)
<!-- Reviewable:end -->
