### PR TITLE
Add "bmctool exec" command

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -11,6 +11,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var newConnector = connector.NewConnector
+
 // execCmd represents the exec command
 var execCmd = &cobra.Command{
 	Use:   "exec <host> <command>",
@@ -69,14 +71,15 @@ func exec(host, cmd string) {
 				Dst: int(bmcPort),
 			},
 		}
-		sshForwarder := forwarder.New(tunnelHost, sshUser, bmcHost, ports)
+		sshForwarder := newForwarder(tunnelHost, sshUser, bmcHost, ports)
 		sshForwarder.Start(context.Background())
 		connectionConfig.Hostname = "127.0.0.1"
 		connectionConfig.Port = localPort
 	}
 
 	// Establish connection to the BMC.
-	conn, err := connector.NewConnector().NewConnection(connectionConfig)
+	c := newConnector()
+	conn, err := c.NewConnection(connectionConfig)
 	rtx.Must(err, "Cannot connect to BMC: %s", bmcHost)
 	defer conn.Close()
 

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -58,6 +58,8 @@ func Test_exec(t *testing.T) {
 	newForwarder = newForwarderMock
 
 	useTunnel = true
+	tunnelHost = "test"
+	bmcUser = "test"
 	exec("mlab1d.tst01", "help")
 
 	newForwarder = oldNewForwarder

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/m-lab/reboot-service/connector"
+
+	"github.com/m-lab/reboot-service/creds"
+	"github.com/m-lab/reboot-service/creds/credstest"
+)
+
+// Mock objects for Connector/Connection.
+type mockConnector struct{}
+
+type mockConnection struct{}
+
+func (connection *mockConnection) ExecDRACShell(string) (string, error) {
+	return "Not implemented.", nil
+}
+
+func (connection *mockConnection) Reboot() (string, error) {
+	return "Not implemented.", nil
+}
+func (connection *mockConnection) Close() error {
+	return nil
+}
+
+func (connector *mockConnector) NewConnection(config *connector.ConnectionConfig) (connector.Connection, error) {
+	return &mockConnection{}, nil
+}
+
+func Test_exec(t *testing.T) {
+	// Create fake Credentials.
+	fakeCreds := &creds.Credentials{
+		Address:  "127.0.0.1",
+		Hostname: "mlab1d.tst01.lga0t.measurement-lab.org",
+		Username: "username",
+		Password: "password",
+		Model:    "DRAC",
+	}
+
+	oldCredsNewProvider := credsNewProvider
+	oldNewConnector := newConnector
+	oldNewForwarder := newForwarder
+
+	// Set up a FakeProvider with fake credentials.
+	prov := credstest.NewProvider()
+	prov.AddCredentials(context.Background(), "mlab1d.tst01.measurement-lab.org", fakeCreds)
+	credsNewProvider = func(creds.Connector, string, string) (creds.Provider, error) {
+		return prov, nil
+	}
+
+	newConnector = func() connector.Connector {
+		return &mockConnector{}
+	}
+
+	newForwarder = newForwarderMock
+
+	useTunnel = true
+	exec("mlab1d.tst01", "help")
+
+	newForwarder = oldNewForwarder
+	credsNewProvider = oldCredsNewProvider
+	newConnector = oldNewConnector
+}

--- a/cmd/forward.go
+++ b/cmd/forward.go
@@ -21,8 +21,7 @@ var (
 )
 
 var (
-	newForwarder = forwarder.New
-	forwardCmd   = &cobra.Command{
+	forwardCmd = &cobra.Command{
 		Use:   "forward <host>",
 		Short: "Forward ports via an SSH tunnel",
 		Long: `This command creates an SSH tunnel to a given <host>.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/m-lab/bmctool/forwarder"
 	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/reboot-service/creds"
 	"github.com/spf13/cobra"
@@ -30,6 +31,7 @@ var (
 	// These allow for testing.
 	credsNewProvider = creds.NewProvider
 	osExit           = os.Exit
+	newForwarder     = forwarder.New
 	// rootCmd represents the base command when called without any subcommands
 	rootCmd = &cobra.Command{
 		Use: "bmctool",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"time"
 
 	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/reboot-service/creds"
@@ -15,6 +16,9 @@ const (
 	prodProjectID    = "mlab-oti"
 	stagingProjectID = "mlab-staging"
 	sandboxProjectID = "mlab-sandbox"
+	defaultBMCPort   = 806
+	defaultLocalPort = 8060
+	bmcTimeout       = 30 * time.Second
 )
 
 var (


### PR DESCRIPTION
This PR adds the `bmctool exec` command, to run arbitrary commands on an BMC. It optionally tunnels through a third host. 

Examples:
- `bmctool exec mlab1d.lga0t help` - run `help` on the BMC without tunneling
- `bmctool exec --tunnel --localport 1234 --bmcport 22 mlab1d.lga0t` - run `help` on the BMC with tunneling and using a non-standard SSH port (22) and local forwarding port (1234)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/bmctool/32)
<!-- Reviewable:end -->
