### PR TITLE
Implement "bmctool list" subcommand

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -14,7 +14,7 @@ var listCmd = &cobra.Command{
 	Short: "List all the available BMCs.",
 	Long: `This command lists all the BMCs stored on Google Cloud Datastore.
 
-The GCP project to use can be specified by providing the --project flag`,
+The GCP project to use must be specified by providing the --project flag`,
 	Run: func(cmd *cobra.Command, args []string) {
 		listBMCs()
 	},
@@ -27,6 +27,8 @@ func init() {
 func listBMCs() {
 	// If no project ID has been specified, don't do anything.
 	if projectID == "" {
+		fmt.Println("The GCP project to use must be specified by " +
+			"providing the --project flag")
 		osExit(1)
 	}
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/m-lab/go/rtx"
+	"github.com/m-lab/reboot-service/creds"
+	"github.com/spf13/cobra"
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list [flags]",
+	Short: "List all the available BMCs.",
+	Long: `This command lists all the BMCs stored on Google Cloud Datastore.
+
+The GCP project to use can be specified by providing the --project flag`,
+	Run: func(cmd *cobra.Command, args []string) {
+		listBMCs()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+}
+
+func listBMCs() {
+	// If no project ID has been specified, don't do anything.
+	if projectID == "" {
+		osExit(1)
+	}
+
+	provider, err := credsNewProvider(&creds.DatastoreConnector{}, projectID, namespace)
+	rtx.Must(err, "Cannot connect to Datastore")
+
+	creds, err := provider.ListCredentials(context.Background())
+	rtx.Must(err, "Cannot read credentials list")
+
+	for _, c := range creds {
+		fmt.Println(c.Hostname)
+	}
+}

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/m-lab/reboot-service/creds"
+	"github.com/m-lab/reboot-service/creds/credstest"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_listBMCs(t *testing.T) {
+	// Create fake Credentials.
+	fakeCreds := &creds.Credentials{
+		Address:  "127.0.0.1",
+		Hostname: "mlab4d.lga0t.measurement-lab.org",
+		Username: "username",
+		Password: "password",
+		Model:    "DRAC",
+	}
+
+	oldCredsNewProvider := credsNewProvider
+
+	// Set up a FakeProvider with fake credentials.
+	prov := credstest.NewProvider()
+	prov.AddCredentials(context.Background(), "mlab4d.lga0t.measurement-lab.org", fakeCreds)
+	credsNewProvider = func(creds.Connector, string, string) (creds.Provider, error) {
+		return prov, nil
+	}
+
+	// Replace osExit so that tests don't stop running.
+	osExit = func(code int) {
+		if code != 1 {
+			t.Fatalf("Expected a 1 exit code, got %d.", code)
+		}
+
+		panic("os.Exit called")
+	}
+
+	// listBMCs() should fails when called without --project.
+	projectID = ""
+	assert.PanicsWithValue(t, "os.Exit called", listBMCs,
+		"os.Exit was not called")
+
+	projectID = "test-project"
+	listBMCs()
+	credsNewProvider = oldCredsNewProvider
+
+}


### PR DESCRIPTION
This PR adds a `bmctool list` subcommand. This command lists the hostnames of all the BMCs stored on Google Cloud Datastore for the specified `--project`. 

The changes here depend on https://github.com/m-lab/reboot-service/pull/30 and tests won't pass until that PR is merged.

Closes https://github.com/m-lab/bmctool/issues/33.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/bmctool/34)
<!-- Reviewable:end -->
