### PR TITLE
Accept v1 and v2 input, always output v2 hostnames

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -52,7 +52,7 @@ func addCredentials() {
 		osExit(1)
 	}
 
-	bmcHost = makeBMCHostname(bmcHost)
+	bmcHost = makeBMCHostname(bmcHost, nameVersion)
 	if projectID == "" {
 		projectID = getProjectID(bmcHost)
 	}

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -53,9 +53,6 @@ func addCredentials() {
 	}
 
 	bmcHost = makeBMCHostname(bmcHost, nameVersion)
-	if projectID == "" {
-		projectID = getProjectID(bmcHost)
-	}
 
 	c := &creds.Credentials{
 		Address:  bmcAddr,

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -38,7 +38,7 @@ func Test_addCredentials(t *testing.T) {
 	}
 
 	// addCredentials should successfully add a new node.
-	// The hostname is intentionally provided with the short name here.
+	// The v1 hostname is intentionally provided with the short name here.
 	bmcHost = "mlab1.lga0t"
 	bmcAddr = "127.0.0.1"
 	bmcUser = "user"

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -30,9 +30,6 @@ func init() {
 // deleteCredentials updates a Credentials entity on Google Cloud Datastore.
 func deleteCredentials() {
 	bmcHost = makeBMCHostname(bmcHost, nameVersion)
-	if projectID == "" {
-		projectID = getProjectID(bmcHost)
-	}
 
 	log.Infof("Deleting credentials for host %v", bmcHost)
 	provider, err := credsNewProvider(&creds.DatastoreConnector{}, projectID, namespace)

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -29,7 +29,7 @@ func init() {
 
 // deleteCredentials updates a Credentials entity on Google Cloud Datastore.
 func deleteCredentials() {
-	bmcHost = makeBMCHostname(bmcHost)
+	bmcHost = makeBMCHostname(bmcHost, nameVersion)
 	if projectID == "" {
 		projectID = getProjectID(bmcHost)
 	}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -37,9 +37,6 @@ func init() {
 
 func exec(host, cmd string) {
 	bmcHost := makeBMCHostname(host, nameVersion)
-	if projectID == "" {
-		projectID = getProjectID(bmcHost)
-	}
 
 	log.Infof("Project: %s", projectID)
 	log.Infof("Fetching credentials for %s", bmcHost)

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -36,7 +36,7 @@ func init() {
 }
 
 func exec(host, cmd string) {
-	bmcHost := makeBMCHostname(host)
+	bmcHost := makeBMCHostname(host, nameVersion)
 	if projectID == "" {
 		projectID = getProjectID(bmcHost)
 	}

--- a/cmd/forward.go
+++ b/cmd/forward.go
@@ -91,7 +91,7 @@ func forward(dstHost string) {
 		log.Error("BMCTUNNELHOST and BMCTUNNELUSER must not be empty.")
 		osExit(1)
 	}
-	dstHost = makeBMCHostname(dstHost)
+	dstHost = makeBMCHostname(dstHost, nameVersion)
 
 	portFwd := []forwarder.Port{}
 	for _, port := range ports {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -33,7 +33,7 @@ func init() {
 // printCredentials retrieves credentials for a given hostname and prints them
 // in JSON format.
 func printCredentials(host string) {
-	bmcHost := makeBMCHostname(host)
+	bmcHost := makeBMCHostname(host, nameVersion)
 	if projectID == "" {
 		projectID = getProjectID(bmcHost)
 	}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -34,9 +34,6 @@ func init() {
 // in JSON format.
 func printCredentials(host string) {
 	bmcHost := makeBMCHostname(host, nameVersion)
-	if projectID == "" {
-		projectID = getProjectID(bmcHost)
-	}
 
 	provider, err := credsNewProvider(&creds.DatastoreConnector{}, projectID, namespace)
 	rtx.Must(err, "Cannot connect to Datastore")

--- a/cmd/keys_set.go
+++ b/cmd/keys_set.go
@@ -44,7 +44,7 @@ func init() {
 }
 
 func setKey(host, idx, key string) {
-	bmcHost := makeBMCHostname(host)
+	bmcHost := makeBMCHostname(host, nameVersion)
 	if projectID == "" {
 		projectID = getProjectID(bmcHost)
 	}

--- a/cmd/keys_set.go
+++ b/cmd/keys_set.go
@@ -45,9 +45,6 @@ func init() {
 
 func setKey(host, idx, key string) {
 	bmcHost := makeBMCHostname(host, nameVersion)
-	if projectID == "" {
-		projectID = getProjectID(bmcHost)
-	}
 
 	log.Infof("Project: %s", projectID)
 	log.Infof("Fetching credentials for %s", bmcHost)

--- a/cmd/reboot.go
+++ b/cmd/reboot.go
@@ -54,7 +54,7 @@ func reboot(host string) {
 		osExit(1)
 	}
 	// Make sure the provided host is a valid M-Lab BMC.
-	host = makeBMCHostname(host)
+	host = makeBMCHostname(host, nameVersion)
 	fullURL := rebootAPIURL + rebootEndpoint + "?host=" + host
 
 	log.Infof("POST %s", fullURL)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,7 +55,7 @@ func Execute() {
 }
 
 func init() {
-	// The --project and --hostname-version flags are used by several commands, thus they are defined
+	// The --project and --name-version flags are used by several commands, thus they are defined
 	// as global ("Persistent") flags here.
 	rootCmd.PersistentFlags().StringVar(&projectID, "project", "",
 		"Project ID to use")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,7 +23,8 @@ const (
 )
 
 var (
-	projectID string
+	projectID   string
+	nameVersion string
 
 	// TODO(kinkade): these patterns should go away in favor of determining the
 	// project from siteinfo.
@@ -54,10 +55,12 @@ func Execute() {
 }
 
 func init() {
-	// The --project flag is used by several commands, thus it's defined
-	// as global ("Persistent") flag here.
+	// The --project and --hostname-version flags are used by several commands, thus they are defined
+	// as global ("Persistent") flags here.
 	rootCmd.PersistentFlags().StringVar(&projectID, "project", "",
 		"Project ID to use")
+	rootCmd.PersistentFlags().StringVar(&nameVersion, "name-version", "v1",
+		"Hostname version to use")
 }
 
 // parseNodeSite extracts node and site from a full hostname.
@@ -83,15 +86,23 @@ func parseNodeSite(hostname string) (string, string, error) {
 // - mlab1d.lga0t.measurement-lab.org
 // - mlab1d-lga0t.measurement-lab.org
 // This function returns the full hostname in any of these cases
-func makeBMCHostname(name string) string {
+func makeBMCHostname(name string, version string) string {
 	node, site, err := parseNodeSite(name)
 	rtx.Must(err, "Cannot extract BMC hostname")
+
+	if projectID == "" {
+		projectID = getProjectID(bmcHost)
+	}
 
 	// All the BMC hostnames must end with "d".
 	if node[len(node)-1:] != "d" {
 		node = node + "d"
 	}
-	return fmt.Sprintf("%s-%s.%s.measurement-lab.org", node, site, prodProjectID)
+
+	if version == "v2" {
+		return fmt.Sprintf("%s-%s.%s.measurement-lab.org", node, site, projectID)
+	}
+	return fmt.Sprintf("%s.%s.measurement-lab.org", node, site)
 }
 
 // getProjectID returns the correct GCP project to use based on the hostname.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,8 @@ const (
 var (
 	projectID string
 
+	// TODO(kinkade): these patterns should go away in favor of determining the
+	// project from siteinfo.
 	sandboxRegex = regexp.MustCompile("[a-zA-Z]{3}[0-9]t")
 	stagingRegex = regexp.MustCompile("^mlab4")
 
@@ -60,7 +62,7 @@ func init() {
 
 // parseNodeSite extracts node and site from a full hostname.
 func parseNodeSite(hostname string) (string, string, error) {
-	regex := regexp.MustCompile("(mlab[1-4]d?)\\.([a-zA-Z]{3}[0-9t]{2}).*")
+	regex := regexp.MustCompile(`(mlab[1-4]d?)[.-]([a-zA-Z]{3}[0-9ct]{2}).*`)
 	result := regex.FindStringSubmatch(hostname)
 	if len(result) != 3 {
 		return "", "",
@@ -73,9 +75,13 @@ func parseNodeSite(hostname string) (string, string, error) {
 // makeBMCHostname returns a full BMC hostname. There are different ways the
 // hostname can be provided:
 // - mlab1.lga0t
+// - mlab1-lga0t
 // - mlab1d.lga0t
+// - mlab1d-lga0t
 // - mlab1.lga0t.measurement-lab.org
+// - mlab1-lga0t.measurement-lab.org
 // - mlab1d.lga0t.measurement-lab.org
+// - mlab1d-lga0t.measurement-lab.org
 // This function returns the full hostname in any of these cases
 func makeBMCHostname(name string) string {
 	node, site, err := parseNodeSite(name)
@@ -85,7 +91,7 @@ func makeBMCHostname(name string) string {
 	if node[len(node)-1:] != "d" {
 		node = node + "d"
 	}
-	return fmt.Sprintf("%s.%s.measurement-lab.org", node, site)
+	return fmt.Sprintf("%s-%s.%s.measurement-lab.org", node, site, prodProjectID)
 }
 
 // getProjectID returns the correct GCP project to use based on the hostname.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -4,55 +4,70 @@ import (
 	"testing"
 )
 
+func init() {
+	nameVersion = "v1"
+}
+
 func Test_makeBMCHostname(t *testing.T) {
 	tests := []struct {
-		name string
-		want string
+		name        string
+		nameVersion string
+		want        string
 	}{
 		{
-			name: "mlab1d.lga0t",
-			want: "mlab1d-lga0t.mlab-oti.measurement-lab.org",
+			name:        "mlab1d.lga0t",
+			nameVersion: "v1",
+			want:        "mlab1d.lga0t.measurement-lab.org",
 		},
 		{
-			name: "mlab1.lga0t",
-			want: "mlab1d-lga0t.mlab-oti.measurement-lab.org",
+			name:        "mlab1.lga0t",
+			nameVersion: "v1",
+			want:        "mlab1d.lga0t.measurement-lab.org",
 		},
 		{
-			name: "mlab1.lga0t.measurement-lab.org",
-			want: "mlab1d-lga0t.mlab-oti.measurement-lab.org",
+			name:        "mlab1.lga0t.measurement-lab.org",
+			nameVersion: "v1",
+			want:        "mlab1d.lga0t.measurement-lab.org",
 		},
 		{
-			name: "mlab1d.lga0t.measurement-lab.org",
-			want: "mlab1d-lga0t.mlab-oti.measurement-lab.org",
+			name:        "mlab1d.lga0t.measurement-lab.org",
+			nameVersion: "v1",
+			want:        "mlab1d.lga0t.measurement-lab.org",
 		},
 		{
-			name: "mlab1d.lga0t.blah",
-			want: "mlab1d-lga0t.mlab-oti.measurement-lab.org",
+			name:        "mlab1d.lga0t.blah",
+			nameVersion: "v1",
+			want:        "mlab1d.lga0t.measurement-lab.org",
 		},
 		{
-			name: "mlab1-lga0t",
-			want: "mlab1d-lga0t.mlab-oti.measurement-lab.org",
+			name:        "mlab1-lga0t",
+			nameVersion: "v2",
+			want:        "mlab1d-lga0t.test-project.measurement-lab.org",
 		},
 		{
-			name: "mlab1d-lga0t",
-			want: "mlab1d-lga0t.mlab-oti.measurement-lab.org",
+			name:        "mlab1d-lga0t",
+			nameVersion: "v2",
+			want:        "mlab1d-lga0t.test-project.measurement-lab.org",
 		},
 		{
-			name: "mlab1-lga0t.lol.example.org",
-			want: "mlab1d-lga0t.mlab-oti.measurement-lab.org",
+			name:        "mlab1-lga0t.lol.example.org",
+			nameVersion: "v2",
+			want:        "mlab1d-lga0t.test-project.measurement-lab.org",
 		},
 		{
-			name: "mlab1-lga0t.mlab-oti.measurement-lab.org",
-			want: "mlab1d-lga0t.mlab-oti.measurement-lab.org",
+			name:        "mlab1-lga0t.test-project.measurement-lab.org",
+			nameVersion: "v2",
+			want:        "mlab1d-lga0t.test-project.measurement-lab.org",
 		},
 		{
-			name: "mlab1d-lga0t.mlab-oti.measurement-lab.org",
-			want: "mlab1d-lga0t.mlab-oti.measurement-lab.org",
+			name:        "mlab1d-lga0t.test-project.measurement-lab.org",
+			nameVersion: "v2",
+			want:        "mlab1d-lga0t.test-project.measurement-lab.org",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := makeBMCHostname(tt.name); got != tt.want {
+			if got := makeBMCHostname(tt.name, tt.nameVersion); got != tt.want {
 				t.Errorf("makeBMCHostname() = %v, want %v", got, tt.want)
 			}
 		})

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -11,23 +11,43 @@ func Test_makeBMCHostname(t *testing.T) {
 	}{
 		{
 			name: "mlab1d.lga0t",
-			want: "mlab1d.lga0t.measurement-lab.org",
+			want: "mlab1d-lga0t.mlab-oti.measurement-lab.org",
 		},
 		{
 			name: "mlab1.lga0t",
-			want: "mlab1d.lga0t.measurement-lab.org",
+			want: "mlab1d-lga0t.mlab-oti.measurement-lab.org",
 		},
 		{
 			name: "mlab1.lga0t.measurement-lab.org",
-			want: "mlab1d.lga0t.measurement-lab.org",
+			want: "mlab1d-lga0t.mlab-oti.measurement-lab.org",
 		},
 		{
 			name: "mlab1d.lga0t.measurement-lab.org",
-			want: "mlab1d.lga0t.measurement-lab.org",
+			want: "mlab1d-lga0t.mlab-oti.measurement-lab.org",
 		},
 		{
 			name: "mlab1d.lga0t.blah",
-			want: "mlab1d.lga0t.measurement-lab.org",
+			want: "mlab1d-lga0t.mlab-oti.measurement-lab.org",
+		},
+		{
+			name: "mlab1-lga0t",
+			want: "mlab1d-lga0t.mlab-oti.measurement-lab.org",
+		},
+		{
+			name: "mlab1d-lga0t",
+			want: "mlab1d-lga0t.mlab-oti.measurement-lab.org",
+		},
+		{
+			name: "mlab1-lga0t.lol.example.org",
+			want: "mlab1d-lga0t.mlab-oti.measurement-lab.org",
+		},
+		{
+			name: "mlab1-lga0t.mlab-oti.measurement-lab.org",
+			want: "mlab1d-lga0t.mlab-oti.measurement-lab.org",
+		},
+		{
+			name: "mlab1d-lga0t.mlab-oti.measurement-lab.org",
+			want: "mlab1d-lga0t.mlab-oti.measurement-lab.org",
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -43,9 +43,6 @@ func init() {
 // setCredentials updates a Credentials entity on Google Cloud Datastore.
 func setCredentials() {
 	bmcHost = makeBMCHostname(bmcHost, nameVersion)
-	if projectID == "" {
-		projectID = getProjectID(bmcHost)
-	}
 
 	log.Infof("Updating credentials for host %v", bmcHost)
 	provider, err := credsNewProvider(&creds.DatastoreConnector{}, projectID, namespace)

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -42,7 +42,7 @@ func init() {
 
 // setCredentials updates a Credentials entity on Google Cloud Datastore.
 func setCredentials() {
-	bmcHost = makeBMCHostname(bmcHost)
+	bmcHost = makeBMCHostname(bmcHost, nameVersion)
 	if projectID == "" {
 		projectID = getProjectID(bmcHost)
 	}


### PR DESCRIPTION
This PR will cause bmctool to always output v2 hostnames (project-decorated/flat). v2 hostnames are completely usable in all projects today, and tools can begin using them. With the PR, bmctool can still accept v1 names as input, but will output a v2 name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/bmctool/36)
<!-- Reviewable:end -->
