### PR TITLE
Use host.Parse() to detect project

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/m-lab/bmctool/forwarder"
+	"github.com/m-lab/go/host"
 	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/reboot-service/creds"
 	"github.com/spf13/cobra"
@@ -106,11 +107,18 @@ func makeBMCHostname(name string, version string) string {
 }
 
 // getProjectID returns the correct GCP project to use based on the hostname.
-func getProjectID(host string) string {
-	if sandboxRegex.MatchString(host) {
+func getProjectID(hostname string) string {
+	// First, try parsing the hostname with host.Parse().
+	parsed, err := host.Parse(hostname)
+	if err == nil && parsed.Project != "" {
+		return parsed.Project
+	}
+	// If host.Parse() fails, try with regular expressions.
+	// TODO: replace this with siteinfo's projects.json.
+	if sandboxRegex.MatchString(hostname) {
 		return sandboxProjectID
 	}
-	if stagingRegex.MatchString(host) {
+	if stagingRegex.MatchString(hostname) {
 		return stagingProjectID
 	}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -13,7 +13,6 @@ func Test_makeBMCHostname(t *testing.T) {
 		name        string
 		nameVersion string
 		want        string
-		wantErr     bool
 	}{
 		{
 			name:        "mlab1d.lga0t",

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -13,6 +13,7 @@ func Test_makeBMCHostname(t *testing.T) {
 		name        string
 		nameVersion string
 		want        string
+		wantErr     bool
 	}{
 		{
 			name:        "mlab1d.lga0t",
@@ -42,17 +43,27 @@ func Test_makeBMCHostname(t *testing.T) {
 		{
 			name:        "mlab1-lga0t",
 			nameVersion: "v2",
-			want:        "mlab1d-lga0t.test-project.measurement-lab.org",
+			want:        "mlab1d-lga0t.mlab-sandbox.measurement-lab.org",
 		},
 		{
 			name:        "mlab1d-lga0t",
 			nameVersion: "v2",
-			want:        "mlab1d-lga0t.test-project.measurement-lab.org",
+			want:        "mlab1d-lga0t.mlab-sandbox.measurement-lab.org",
+		},
+		{
+			name:        "mlab4-abc01",
+			nameVersion: "v2",
+			want:        "mlab4d-abc01.mlab-staging.measurement-lab.org",
 		},
 		{
 			name:        "mlab1-lga0t.lol.example.org",
 			nameVersion: "v2",
-			want:        "mlab1d-lga0t.test-project.measurement-lab.org",
+			want:        "mlab1d-lga0t.mlab-sandbox.measurement-lab.org",
+		},
+		{
+			name:        "mlab4-abc01.lol.example.org",
+			nameVersion: "v2",
+			want:        "mlab4d-abc01.mlab-staging.measurement-lab.org",
 		},
 		{
 			name:        "mlab1-lga0t.test-project.measurement-lab.org",
@@ -65,8 +76,10 @@ func Test_makeBMCHostname(t *testing.T) {
 			want:        "mlab1d-lga0t.test-project.measurement-lab.org",
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			projectID = ""
 			if got := makeBMCHostname(tt.name, tt.nameVersion); got != tt.want {
 				t.Errorf("makeBMCHostname() = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
This PR is the first step towards project auto-detection in bmctool.

It uses `host.Parse()` to try and detect the project when the hostname is provided to bmctool in v2 format, and falls back to regular expressions when both 1. `--project` hasn't been specified and 2. `host.Parse()` cannot detect the project name.

It also fixes a problem in the unit test where success/failure depended on the order of execution since `projectID` is a global variable that was not reset to `""` before each test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/bmctool/38)
<!-- Reviewable:end -->
