### PR TITLE
Implement project auto-detection using siteinfo

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -56,7 +56,7 @@ func addCredentials() {
 
 	c := &creds.Credentials{
 		Address:  bmcAddr,
-		Hostname: bmcHost,
+		Hostname: bmcNode.String(),
 		Model:    "DRAC",
 		Username: bmcUser,
 		Password: bmcPass,

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -52,7 +52,7 @@ func addCredentials() {
 		osExit(1)
 	}
 
-	bmcHost = makeBMCHostname(bmcHost)
+	bmcNode := makeBMCHostname(bmcHost)
 
 	c := &creds.Credentials{
 		Address:  bmcAddr,
@@ -62,22 +62,22 @@ func addCredentials() {
 		Password: bmcPass,
 	}
 
-	log.Infof("Adding credentials for host %v", bmcHost)
+	log.Infof("Adding credentials for host %v", bmcNode.String())
 
-	provider, err := credsNewProvider(&creds.DatastoreConnector{}, projectID, namespace)
+	provider, err := credsNewProvider(&creds.DatastoreConnector{}, bmcNode.Project, namespace)
 	rtx.Must(err, "Cannot connect to Datastore")
 	defer provider.Close()
 
 	// Provider.AddCredentials will create the entity regardless of whether it
 	// exists already or not, so we need to explicitly check to prevent
 	// overriding the existing entity by mistake.
-	_, err = provider.FindCredentials(context.Background(), bmcHost)
+	_, err = provider.FindCredentials(context.Background(), bmcNode.String())
 	if err == nil {
-		log.Errorf("Credentials for hostname %v already exist", bmcHost)
+		log.Errorf("Credentials for hostname %v already exist", bmcNode.String())
 		osExit(1)
 	}
 
-	rtx.Must(provider.AddCredentials(context.Background(), bmcHost, c),
+	rtx.Must(provider.AddCredentials(context.Background(), bmcNode.String(), c),
 		"Error while adding Credentials")
 
 	fmt.Print(c)

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -29,20 +29,20 @@ func init() {
 
 // deleteCredentials updates a Credentials entity on Google Cloud Datastore.
 func deleteCredentials() {
-	bmcHost = makeBMCHostname(bmcHost)
+	bmcNode := makeBMCHostname(bmcHost)
 
-	log.Infof("Deleting credentials for host %v", bmcHost)
-	provider, err := credsNewProvider(&creds.DatastoreConnector{}, projectID, namespace)
+	log.Infof("Deleting credentials for host %v", bmcNode.String())
+	provider, err := credsNewProvider(&creds.DatastoreConnector{}, bmcNode.Project, namespace)
 	rtx.Must(err, "Cannot connect to Datastore")
 	provider.Close()
 
-	err = provider.DeleteCredentials(context.Background(), bmcHost)
+	err = provider.DeleteCredentials(context.Background(), bmcNode.String())
 	// Note: Deleting a key from Datastore does not return a NoSuchEntity error
 	// if the specified key does not exist, thus the error will be nil unless
 	// something else goes wrong during the deletion.
 	// See: https://github.com/googleapis/google-cloud-go/issues/501
 	if err != nil {
-		log.Errorf("Cannot delete credentials for %s: %v", bmcHost, err)
+		log.Errorf("Cannot delete credentials for %s: %v", bmcNode.String(), err)
 		osExit(1)
 	}
 

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -13,7 +13,7 @@ func Test_deleteCredentials(t *testing.T) {
 	// Create fake Credentials.
 	fakeCreds := &creds.Credentials{
 		Address:  "127.0.0.1",
-		Hostname: "mlab4d.lga0t.measurement-lab.org",
+		Hostname: "mlab4d-lga0t.mlab-sandbox.measurement-lab.org",
 		Username: "username",
 		Password: "password",
 		Model:    "DRAC",

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -83,7 +83,7 @@ func Test_exec(t *testing.T) {
 	useTunnel = true
 	tunnelHost = "test"
 	sshUser = "test"
-	exec("mlab1d-lga0t", "help")
+	exec("mlab1d-lga0t.mlab-sandbox.measurement-lab.org", "help")
 
 	if c.conn.execCalls != 1 {
 		t.Errorf("exec called but execCalls != 1")

--- a/cmd/forward.go
+++ b/cmd/forward.go
@@ -91,7 +91,7 @@ func forward(dstHost string) {
 		log.Error("BMCTUNNELHOST and BMCTUNNELUSER must not be empty.")
 		osExit(1)
 	}
-	dstHost = makeBMCHostname(dstHost)
+	bmcNode := makeBMCHostname(dstHost)
 
 	portFwd := []forwarder.Port{}
 	for _, port := range ports {
@@ -99,7 +99,7 @@ func forward(dstHost string) {
 		rtx.Must(err, "Cannot parse provided port")
 		portFwd = append(portFwd, p)
 	}
-	forwarder := newForwarder(tunnelHost, sshUser, dstHost, portFwd)
+	forwarder := newForwarder(tunnelHost, sshUser, bmcNode.String(), portFwd)
 
 	ctx := context.Background()
 	rtx.Must(forwarder.Start(context.Background()), "Cannot start SSH tunnel")

--- a/cmd/forward_test.go
+++ b/cmd/forward_test.go
@@ -99,6 +99,6 @@ func Test_forward(t *testing.T) {
 	_, cancel := context.WithCancel(context.Background())
 
 	// forward() only returns when the context is canceled.
-	go forward("mlab1.tst01")
+	go forward("mlab1-lga0t.mlab-sandbox.measurement-lab.org")
 	cancel()
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -33,13 +33,13 @@ func init() {
 // printCredentials retrieves credentials for a given hostname and prints them
 // in JSON format.
 func printCredentials(host string) {
-	bmcHost := makeBMCHostname(host)
+	node := makeBMCHostname(host)
 
-	provider, err := credsNewProvider(&creds.DatastoreConnector{}, projectID, namespace)
+	provider, err := credsNewProvider(&creds.DatastoreConnector{}, node.Project, namespace)
 	rtx.Must(err, "Cannot connect to Datastore")
 	defer provider.Close()
 
-	creds, err := provider.FindCredentials(context.Background(), bmcHost)
+	creds, err := provider.FindCredentials(context.Background(), node.String())
 	rtx.Must(err, "Cannot fetch credentials")
 
 	fmt.Print(creds)

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -33,13 +33,13 @@ func init() {
 // printCredentials retrieves credentials for a given hostname and prints them
 // in JSON format.
 func printCredentials(host string) {
-	node := makeBMCHostname(host)
+	bmcNode := makeBMCHostname(host)
 
-	provider, err := credsNewProvider(&creds.DatastoreConnector{}, node.Project, namespace)
+	provider, err := credsNewProvider(&creds.DatastoreConnector{}, bmcNode.Project, namespace)
 	rtx.Must(err, "Cannot connect to Datastore")
 	defer provider.Close()
 
-	creds, err := provider.FindCredentials(context.Background(), node.String())
+	creds, err := provider.FindCredentials(context.Background(), bmcNode.String())
 	rtx.Must(err, "Cannot fetch credentials")
 
 	fmt.Print(creds)

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -28,7 +28,7 @@ func Test_printCredentials(t *testing.T) {
 	}
 
 	// printCredentials is intentionally called with a short name here.
-	printCredentials("mlab4.lga0t")
+	printCredentials("mlab4-lga0t.mlab-sandbox.measurement-lab.org")
 
 	credsNewProvider = oldCredsNewProvider
 }

--- a/cmd/reboot.go
+++ b/cmd/reboot.go
@@ -54,8 +54,8 @@ func reboot(host string) {
 		osExit(1)
 	}
 	// Make sure the provided host is a valid M-Lab BMC.
-	host = makeBMCHostname(host)
-	fullURL := rebootAPIURL + rebootEndpoint + "?host=" + host
+	bmcNode := makeBMCHostname(host)
+	fullURL := rebootAPIURL + rebootEndpoint + "?host=" + bmcNode.String()
 
 	log.Infof("POST %s", fullURL)
 	resp, err := httpClient.Post(fullURL, "text/plain", nil)

--- a/cmd/reboot_test.go
+++ b/cmd/reboot_test.go
@@ -39,7 +39,7 @@ func Test_reboot(t *testing.T) {
 	// If REBOOTAPIURL isn't set, reboot() should fail.
 	rebootAPIURL = ""
 	assert.PanicsWithValue(t, "os.Exit called", func() {
-		reboot("mlab1d.lga0t.measurement-lab.org")
+		reboot("mlab1d-lga0t.mlab-sandbox.measurement-lab.org")
 	}, "os.Exit was not called")
 	rebootAPIURL = "dummy"
 
@@ -64,13 +64,13 @@ func Test_reboot(t *testing.T) {
 
 	// Rebooting an mlab4 will always fail.
 	assert.PanicsWithValue(t, "os.Exit called", func() {
-		reboot("mlab4d.lga0t.measurement-lab.org")
+		reboot("mlab4d-lga0t.mlab-sandbox.measurement-lab.org")
 	}, "os.Exit was not called")
 
 	// Successful reboot, stdout should contain the expected message.
 	var buf bytes.Buffer
 	log.SetOutput(&buf)
-	reboot("mlab1d.lga0t.measurement-lab.org")
+	reboot("mlab1d-lga0t.mlab-sandbox.measurement-lab.org")
 	log.SetOutput(os.Stderr)
 
 	if !strings.Contains(buf.String(), "Server power operation successful.") {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,15 +61,13 @@ func Execute() {
 }
 
 func init() {
-	// The --project and --name-version flags are used by several commands, thus they are defined
-	// as global ("Persistent") flags here.
+	// The --project flag is used by several commands, thus it is defined
+	// as a global ("Persistent") flag here.
 	rootCmd.PersistentFlags().StringVar(&projectID, "project", "",
 		"Project ID to use")
-	rootCmd.PersistentFlags().StringVar(&nameVersion, "name-version", "v2",
-		"Hostname version to use")
 }
 
-// parseNodeSite extracts node and site from a full hostname.
+// parseNodeSite extracts node and site from a hostname.
 func parseNodeSite(hostname string) (string, string, error) {
 	regex := regexp.MustCompile(`(mlab[1-4]d?)[.-]([a-zA-Z]{3}[0-9ct]{2}).*`)
 	result := regex.FindStringSubmatch(hostname)
@@ -92,6 +90,8 @@ func parseNodeSite(hostname string) (string, string, error) {
 // - mlab1-lga0t.measurement-lab.org
 // - mlab1d.lga0t.measurement-lab.org
 // - mlab1d-lga0t.measurement-lab.org
+// - mlab1-lga0t.mlab-sandbox.measurement-lab.org
+// - mlab1d-lga0t.mlab-sandbox.measurement-lab.org
 //
 // If the hostname is not complete, this function retrieves the project ID
 // from siteinfo. If the machine/site combination cannot be found in siteinfo,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,82 +1,163 @@
 package cmd
 
 import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"net/http"
 	"testing"
+
+	"github.com/m-lab/go/host"
 )
 
+type failingReadCloser struct{}
+
+func (*failingReadCloser) Read([]byte) (int, error) {
+	return 0, errors.New("Read() error")
+}
+func (*failingReadCloser) Close() error {
+	return errors.New("Close() error")
+}
+
 func Test_makeBMCHostname(t *testing.T) {
+	fakeNode := host.Name{
+		Machine: "mlab1d",
+		Site:    "lga0t",
+		Project: "mlab-sandbox",
+	}
+
+	projectsJSON := `{
+		"mlab1-lga0t": "mlab-sandbox"
+		}`
+
+	var resp *http.Response
+
+	oldHTTPGet := httpGet
+	httpGet = func(string) (*http.Response, error) {
+		return resp, nil
+	}
+
 	tests := []struct {
 		name        string
 		nameVersion string
-		want        string
+		want        host.Name
 	}{
 		{
 			name: "mlab1-lga0t",
-			want: "mlab1d-lga0t.mlab-sandbox.measurement-lab.org",
+			want: fakeNode,
 		},
 		{
 			name: "mlab1d-lga0t",
-			want: "mlab1d-lga0t.mlab-sandbox.measurement-lab.org",
-		},
-		{
-			name: "mlab4-abc01",
-			want: "mlab4d-abc01.mlab-staging.measurement-lab.org",
+			want: fakeNode,
 		},
 		{
 			name: "mlab1-lga0t.lol.example.org",
-			want: "mlab1d-lga0t.mlab-sandbox.measurement-lab.org",
-		},
-		{
-			name: "mlab4-abc01.lol.example.org",
-			want: "mlab4d-abc01.mlab-staging.measurement-lab.org",
+			want: fakeNode,
 		},
 		{
 			name: "mlab1-lga0t.test-project.measurement-lab.org",
-			want: "mlab1d-lga0t.test-project.measurement-lab.org",
+			want: host.Name{
+				Project: "test-project",
+				Machine: "mlab1d",
+				Site:    "lga0t",
+			},
 		},
 		{
 			name: "mlab1d-lga0t.test-project.measurement-lab.org",
-			want: "mlab1d-lga0t.test-project.measurement-lab.org",
+			want: host.Name{
+				Project: "test-project",
+				Machine: "mlab1d",
+				Site:    "lga0t",
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			projectID = ""
-			if got := makeBMCHostname(tt.name); got != tt.want {
+			resp = &http.Response{
+				Body:       ioutil.NopCloser(bytes.NewBufferString(projectsJSON)),
+				StatusCode: http.StatusOK,
+			}
+
+			got := makeBMCHostname(tt.name)
+			if tt.want.Machine != got.Machine || tt.want.Site != got.Site ||
+				tt.want.Project != got.Project {
 				t.Errorf("makeBMCHostname() = %v, want %v", got, tt.want)
 			}
 		})
 	}
+
+	httpGet = oldHTTPGet
 }
 
 func Test_getProjectID(t *testing.T) {
-	tests := []struct {
-		name string
-		host string
-		want string
-	}{
-		{
-			name: "prod-node",
-			host: "mlab1.abc01.measurement-lab.org",
-			want: "mlab-oti",
-		},
-		{
-			name: "staging-node",
-			host: "mlab4.abc01.measurement-lab.org",
-			want: "mlab-staging",
-		},
-		{
-			name: "sandbox-node",
-			host: "mlab4.abc0t.measurement-lab.org",
-			want: "mlab-sandbox",
-		},
+	node := host.Name{
+		Machine: "mlab1",
+		Site:    "lga0t",
+		Domain:  "measurement-lab.org",
+		Version: "v2",
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := getProjectID(tt.host); got != tt.want {
-				t.Errorf("getProjectID() = %v, want %v", got, tt.want)
-			}
-		})
+
+	projectsJSON := `{
+		"mlab1-lga0t": "mlab-sandbox"
+		}`
+
+	resp := &http.Response{
+		Body:       ioutil.NopCloser(bytes.NewBufferString(projectsJSON)),
+		StatusCode: http.StatusOK,
 	}
+
+	oldHTTPGet := httpGet
+	httpGet = func(string) (*http.Response, error) {
+		return resp, nil
+	}
+
+	// A project for this site exists - OK case.
+	project, err := getProjectID(node)
+	if err != nil {
+		t.Errorf("getProjectID() returned an error")
+	}
+	if project != "mlab-sandbox" {
+		t.Errorf("getProjectID(): expected %v, got %v", "mlab-sandbox",
+			project)
+	}
+
+	// A project for this site does not exist.
+	node.Machine = "mlab2"
+	resp.Body = ioutil.NopCloser(bytes.NewBufferString(projectsJSON))
+	project, err = getProjectID(node)
+	if err == nil {
+		t.Errorf("getProjectID() expected err, got nil")
+	}
+	if project != "" {
+		t.Errorf("getProjectID(): unexpected return value")
+	}
+
+	// Reading the response body fails.
+	resp = &http.Response{
+		Body:       &failingReadCloser{},
+		StatusCode: http.StatusOK,
+	}
+	project, err = getProjectID(node)
+	if err == nil {
+		t.Errorf("getProjectID(): expected err, got nil")
+	}
+	if project != "" {
+		t.Errorf("getProjectID(): unexpected return value")
+	}
+
+	// http.Get returns an error.
+	httpGet = func(string) (*http.Response, error) {
+		return nil, errors.New("error")
+	}
+	project, err = getProjectID(node)
+	if err == nil {
+		t.Errorf("getProjectID(): expected err, got nil")
+	}
+	if project != "" {
+		t.Errorf("getProjectID(): unexpected return value")
+	}
+
+	httpGet = oldHTTPGet
 }

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -42,16 +42,16 @@ func init() {
 
 // setCredentials updates a Credentials entity on Google Cloud Datastore.
 func setCredentials() {
-	bmcHost = makeBMCHostname(bmcHost)
+	bmcNode := makeBMCHostname(bmcHost)
 
-	log.Infof("Updating credentials for host %v", bmcHost)
+	log.Infof("Updating credentials for host %v", bmcNode.String())
 	provider, err := credsNewProvider(&creds.DatastoreConnector{}, projectID, namespace)
 	rtx.Must(err, "Cannot connect to Datastore")
 	defer provider.Close()
 
-	creds, err := provider.FindCredentials(context.Background(), bmcHost)
+	creds, err := provider.FindCredentials(context.Background(), bmcNode.String())
 	if err != nil {
-		log.Errorf("Error while retrieving credentials for %s: %v", bmcHost, err)
+		log.Errorf("Error while retrieving credentials for %s: %v", bmcNode.String(), err)
 		osExit(1)
 	}
 
@@ -66,7 +66,7 @@ func setCredentials() {
 	if bmcPass != "" {
 		creds.Password = bmcPass
 	}
-	rtx.Must(provider.AddCredentials(context.Background(), bmcHost, creds),
+	rtx.Must(provider.AddCredentials(context.Background(), bmcNode.String(), creds),
 		"Error while adding Credentials")
 	fmt.Print(creds)
 }

--- a/cmd/set_test.go
+++ b/cmd/set_test.go
@@ -39,7 +39,7 @@ func Test_setCredentials(t *testing.T) {
 	}
 
 	// setCredentials should successfully change an existing entity
-	bmcHost = "mlab4d-lga0t"
+	bmcHost = "mlab4d-lga0t.mlab-sandbox.measurement-lab.org"
 	bmcUser = "testuser"
 	bmcPass = "testpass"
 	bmcAddr = "127.0.0.2"
@@ -58,7 +58,7 @@ func Test_setCredentials(t *testing.T) {
 	}
 
 	// bmctool set should fail if called on a non-existing host.
-	bmcHost = "mlab1-abc01"
+	bmcHost = "mlab1-abc01.mlab-sandbox.measurement-lab.org"
 	assert.PanicsWithValue(t, "os.Exit called", setCredentials,
 		"os.Exit was not called")
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/apex/log v1.4.0
 	github.com/m-lab/go v0.1.42
 	github.com/m-lab/reboot-service v0.5.1
+	github.com/segmentio/encoding v0.1.14
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -276,6 +276,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/segmentio/encoding v0.1.14 h1:BfnglNbNRohLaBLf93uP5/IwKqeWrezXK/g6IRnj75c=
+github.com/segmentio/encoding v0.1.14/go.mod h1:RWhr02uzMB9gQC1x+MfYxedtmBibb9cZ6Vv9VxRSSbw=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=


### PR DESCRIPTION
This change adds project auto-detection querying siteinfo, except if the hostname was provided complete with the project ID (e.g. `mlab1d-lga0t.mlab-sandbox.measurement-lab.org`.)

Closes #35.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/bmctool/42)
<!-- Reviewable:end -->
