### PR TITLE
Change the default BMC port to 22

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	namespace        = "reboot-api"
-	defaultBMCPort   = 806
+	defaultBMCPort   = 22
 	defaultLocalPort = 8060
 	bmcTimeout       = 30 * time.Second
 	siteinfoBaseURL  = "https://siteinfo.mlab-oti.measurementlab.net/v2/"


### PR DESCRIPTION
This PR changes the default DRAC port used by bmctool to 22. This change is related to automating the DRAC configuration during stage1/2 (m-lab/epoxy#94)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/bmctool/44)
<!-- Reviewable:end -->
